### PR TITLE
Prevent crash if SYPaginatorResources.bundle is missing

### DIFF
--- a/SYPaginator/SYPageControl.m
+++ b/SYPaginator/SYPageControl.m
@@ -109,7 +109,15 @@ static NSInteger const kSYPageControlMaxNumberOfDots = 12;
 		numberFormatter.currencySymbol = @"";
 		numberFormatter.maximumFractionDigits = 0;
 	});
-	_textLabel.text = [NSString stringWithFormat:SYPaginatorLocalizedString(@"PAGE_OF_TOTAL"),
+	
+	NSString *format = SYPaginatorLocalizedString(@"PAGE_OF_TOTAL");
+	if (!format) {
+		NSLog(@"[SYPaginator] WARNING: SYPaginatorResources.bundle is missing. Please add it your copy resources build phase.");
+		_textLabel.text = nil;
+		return;
+	}
+	
+	_textLabel.text = [NSString stringWithFormat:format,
 					   [numberFormatter stringFromNumber:[NSNumber numberWithInteger:_currentPage + 1]],
 					   [numberFormatter stringFromNumber:[NSNumber numberWithInteger:_numberOfPages]]];
 }


### PR DESCRIPTION
If the bundle is missing, `stringWithFormat:` will crash because the string format from the bundle is `nil`. It would be better to just log and set the text to nil instead of crash.
