### PR TITLE
Fix a bug causing reloadData to fail for new content

### DIFF
--- a/SYPaginator/SYPaginatorView.m
+++ b/SYPaginator/SYPaginatorView.m
@@ -402,7 +402,7 @@
 
 
 - (void)_setCurrentPageIndex:(NSInteger)targetPage animated:(BOOL)animated scroll:(BOOL)scroll forcePreload:(BOOL)forcePreload {
-	if (_currentPageIndex == targetPage && _pageSetViaPublicMethod != YES) {
+	if (_currentPageIndex == targetPage && _pageSetViaPublicMethod) {
 		return;
 	}
 	


### PR DESCRIPTION
Steps to reproduce the bug:
1. Present an SYPaginator with a set of images
2. Change the data source's set of images
3. Call reloadData on the paginator

**Expected:** Paginator content updates showing new image set
**Actual:** CurrentPage is removed and new content is not shown until user changes index

`_setCurrentPageIndex` rejects requests if the index has not changed and the call was made internally. 

I assume the original intention was the opposite; do nothing when the developer requests a page change to the currently shown index.
