### PR TITLE
Fix reloadData bug causing no refresh when content changes

### DIFF
--- a/SYPaginator/SYPaginatorView.m
+++ b/SYPaginator/SYPaginatorView.m
@@ -28,6 +28,7 @@
 	NSMutableDictionary *_reuseablePages;
 	BOOL _pageControlUsed;
 	BOOL _pageSetViaPublicMethod;
+	BOOL _pageContentNeedsRefresh;
 }
 
 @synthesize scrollView = _scrollView;
@@ -155,6 +156,7 @@
 #pragma mark - Managing data
 
 - (void)reloadData {
+	_pageContentNeedsRefresh = YES;
 	[self reloadDataRemovingCurrentPage:YES];
 }
 
@@ -402,7 +404,7 @@
 
 
 - (void)_setCurrentPageIndex:(NSInteger)targetPage animated:(BOOL)animated scroll:(BOOL)scroll forcePreload:(BOOL)forcePreload {
-	if (_currentPageIndex == targetPage && _pageSetViaPublicMethod != YES) {
+	if (_currentPageIndex == targetPage && _pageSetViaPublicMethod != YES && _pageContentNeedsRefresh != YES) {
 		return;
 	}
 	
@@ -449,6 +451,7 @@
 	}
 	
 	_pageSetViaPublicMethod = NO;
+	_pageContentNeedsRefresh = NO;
 }
 
 


### PR DESCRIPTION
`reloadData` has a bug introduced in 7d91f780875c28985891d4681b772506a8a2e8e1 which causes new content to not refresh

**Steps to reproduce:**
- Display an SYPaginator with several pages of images
- Alter the data source, such that `-paginatorView:viewForPageAtIndex:` will return new pages/content
- Call `[paginatorView reloadData]`

**Expected result**
- SYPaginator updates to display the new set of pages

**Actual result**
- SYPaginator does not update. `viewForPageAtIndex` is not called

This PR bypasses that issue by allowing "non-public" calls to `_setCurrentPageIndex` to request a content refresh. Feedback appreciated @dorshorst
